### PR TITLE
Load and expose environment on entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,9 @@ LABEL org.opencontainers.image.source https://github.com/moclojer/p001
 
 ADD squid.conf /etc/squid/squid.conf
 ADD entrypoint.sh /src/entrypoint.sh
+ADD .env /src/.env
 
 RUN apt -y update && apt install -y apache2-utils
-#     mkdir -p /usr/lib/squid && \
-#     /usr/lib/squid/security_fake_certverify -c -s /usr/lib/squid/ssl_db -M 4MB
 
 RUN chmod +x /src/entrypoint.sh
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,10 @@
 version: "3"
 services:
   squid:
-    # platform: linux/amd64
     build:
       context: .
-    # command: /apps/squid/sbin/squid -f /apps/squid.conf -NYCd 1
-    # entrypoint: /etc/squid/entrypoint.sh
     ports:
-      - "${P001_PORT:-3128}:3128"
+      - ${P001_PORT:-3128}
     environment:
-      - P001_USER=${P001_USER}
-      - P001_PASS=${P001_PASS}
+      - P001_USER=$P001_USER
+      - P001_PASS=$P001_PASS

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
-htpasswd -c -B -b /etc/squid/htpasswd "$P001_USER" "$P001_PASS"
+source /src/.env
+
+htpasswd -c -B -b /etc/squid/htpasswd ${P001_USER} ${P001_PASS}
 squid -f /etc/squid/squid.conf -NYCd 1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,5 +2,5 @@
 
 source "/src/.env"
 
-htpasswd -c -B -b /etc/squid/htpasswd ${P001_USER} ${P001_PASS}
+htpasswd -c -B -b /etc/squid/htpasswd "${P001_USER}" "${P001_PASS}"
 squid -f /etc/squid/squid.conf -NYCd 1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source /src/.env
+source "/src/.env"
 
 htpasswd -c -B -b /etc/squid/htpasswd ${P001_USER} ${P001_PASS}
 squid -f /etc/squid/squid.conf -NYCd 1

--- a/squid.conf
+++ b/squid.conf
@@ -1,42 +1,5 @@
 auth_param basic program /usr/lib/squid/basic_ncsa_auth /etc/squid/htpasswd
 auth_param basic realm proxy
-
 acl authenticated proxy_auth REQUIRED
-
-acl localnet src 0.0.0.1-0.255.255.255	# RFC 1122 "this" network (LAN)
-acl localnet src 10.0.0.0/8		# RFC 1918 local private network (LAN)
-acl localnet src 100.64.0.0/10		# RFC 6598 shared address space (CGN)
-acl localnet src 169.254.0.0/16 	# RFC 3927 link-local (directly plugged) machines
-acl localnet src 172.16.0.0/12		# RFC 1918 local private network (LAN)
-acl localnet src 192.168.0.0/16		# RFC 1918 local private network (LAN)
-acl localnet src fc00::/7       	# RFC 4193 local private network range
-acl localnet src fe80::/10      	# RFC 4291 link-local (directly plugged) machines
-acl SSL_ports port 443
-# acl Safe_ports port 80		# http
-# acl Safe_ports port 21		# ftp
-acl Safe_ports port 443		# https
-# acl Safe_ports port 70		# gopher
-# acl Safe_ports port 210		# wais
-# acl Safe_ports port 1025-65535	# unregistered ports
-# acl Safe_ports port 280		# http-mgmt
-# acl Safe_ports port 488		# gss-http
-# acl Safe_ports port 591		# filemaker
-# acl Safe_ports port 777		# multiling http
-http_access deny !Safe_ports
-http_access deny CONNECT !SSL_ports
-# http_access allow localhost manager authenticated
-# http_access deny manager
 http_access allow authenticated
-http_access deny to_localhost
-http_access deny to_linklocal
-include /etc/squid/conf.d/*.conf
-http_access deny all
-http_port 3128
-coredump_dir /var/spool/squid
-refresh_pattern ^ftp:		1440	20%	10080
-refresh_pattern -i (/cgi-bin/|\?) 0	0%	0
-refresh_pattern \/(Packages|Sources)(|\.bz2|\.gz|\.xz)$ 0 0% 0 refresh-ims
-refresh_pattern \/Release(|\.gpg)$ 0 0% 0 refresh-ims
-refresh_pattern \/InRelease$ 0 0% 0 refresh-ims
-refresh_pattern \/(Translation-.*)(|\.bz2|\.gz|\.xz)$ 0 0% 0 refresh-ims
-refresh_pattern .		0	20%	4320
+http_port 0.0.0.0:3128


### PR DESCRIPTION
The file `entrypoint.sh` couldn't recognize the environment variables P001_USER and P001_PASS, so, even thought the pass has was created, it was still null.

Also, removed most of our config, since it turned out to be unnecessary, props to this gist: https://gist.github.com/Praseetha-KR/3920ad51c75b8d8a5951122a2cb5e697

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced dynamic environment variable handling via `.env` file for easier configuration management.

- **Improvements**
  - Enhanced environment variable syntax for better readability and maintainability.
  - Streamlined Dockerfile and `docker-compose.yml` by removing unnecessary commented-out lines.

- **Configuration Updates**
  - Updated `entrypoint.sh` to source environment variables dynamically before executing commands.
  - Modified `squid.conf` to refine access rules and HTTP port configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->