### PR TITLE
Expose environment dynamically

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,11 @@ FROM ubuntu/squid:latest
 LABEL maintainer="moclojer.com"
 LABEL org.opencontainers.image.source https://github.com/moclojer/p001
 
+ENV P001_USER "foobar"
+ENV P001_PASS "foobar"
+
 ADD squid.conf /etc/squid/squid.conf
 ADD entrypoint.sh /src/entrypoint.sh
-ADD .env /src/.env
 
 RUN apt -y update && apt install -y apache2-utils
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu/squid:latest
 LABEL maintainer="moclojer.com"
 LABEL org.opencontainers.image.source https://github.com/moclojer/p001
 
-ENV P001_USER "foobar"
-ENV P001_PASS "foobar"
+ENV P001_USER "moclojer"
+ENV P001_PASS "moclojer"
 
 ADD squid.conf /etc/squid/squid.conf
 ADD entrypoint.sh /src/entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ services:
   squid:
     image: ghcr.io/moclojer/p001:latest
     ports:
-      - ${P001_PORT:-3128}
+      - ${P001_PORT:-3128}:3128
     environment:
       - P001_USER=$P001_USER
       - P001_PASS=$P001_PASS

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 Easy docker image to run a simple http proxy server with basic auth (squid).
 
 * **docker image:** `ghcr.io/moclojer/p001:latest`
-* **port:** `3128`, if you want to set a different port you must declare the environment variable `P001_PORT` *(it will proxy in docker)*
-* **user/pass?** if you want to use a proxy with username and password (which we recommend), you need to set the environment variables `P001_USER` and `P001_USER`
+* **port:** `3128` *default*, if you want to set a different port you must declare the environment variable `P001_PORT` *(it will proxy in docker)*
+* **user/pass?** `moclojer` *default*, if you want to use a proxy with username and password (which we recommend), you need to set the environment variables `P001_USER` and `P001_USER`
 
 ## docker compose example
 

--- a/README.md
+++ b/README.md
@@ -14,13 +14,12 @@ Easy docker image to run a simple http proxy server with basic auth (squid).
 version: "3"
 services:
   squid:
-    # platform: linux/amd64
     image: ghcr.io/moclojer/p001:latest
-    # command: /apps/squid/sbin/squid -f /apps/squid.conf -NYCd 1
-    # entrypoint: /etc/squid/entrypoint.sh
     ports:
-      - "${P001_PORT:-3128}:3128"
+      - ${P001_PORT:-3128}
     environment:
-      - P001_USER=${P001_USER}
-      - P001_PASS=${P001_PASS}
+      - P001_USER=$P001_USER
+      - P001_PASS=$P001_PASS
+    volumes:
+      - .env:/src/.env
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
     ports:
-      - ${P001_PORT:-3128}
+      - ${P001_PORT:-3128}:3128
     environment:
       - P001_USER=$P001_USER
       - P001_PASS=$P001_PASS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,5 @@ services:
     environment:
       - P001_USER=$P001_USER
       - P001_PASS=$P001_PASS
+    volumes:
+      - .env:/src/.env

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
+source "/src/.env"
+
 htpasswd -c -B -b /etc/squid/htpasswd "${P001_USER}" "${P001_PASS}"
 squid -f /etc/squid/squid.conf -NYCd 1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
 
-source "/src/.env"
-
 htpasswd -c -B -b /etc/squid/htpasswd "${P001_USER}" "${P001_PASS}"
 squid -f /etc/squid/squid.conf -NYCd 1


### PR DESCRIPTION
Not copying a `to be created file` when building :man_facepalming: anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added environment variables `P001_USER` and `P001_PASS` for better configuration management.
  - Updated environment setup process to no longer source the `.env` file in `entrypoint.sh`.
  - Updated default values and environment variable references for improved clarity and customization.
- **Documentation**
  - Updated README.md with detailed instructions on customizing port and user/pass settings using environment variables.
- **Refactor**
  - Removed the addition of `.env` file to `/src` directory for cleaner project structure.
- **Docker**
  - Added a volume mapping `- .env:/src/.env` for the `P001` service in the `docker-compose.yml` file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->